### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ connexion~=2.7.0
 flask~=1.1.2
 flask-sqlalchemy
 jsonschema~=3.2.0
-sqlalchemy
+sqlalchemy<2.0
 swagger-ui-bundle
 PyJWT~=1.7.1
+markupsafe==2.0.1


### PR DESCRIPTION
sqlalchemy and markupsafe versions had to be fixed in order to get VAmPI running. Apparently, the latest versions of these packages break VAmPI.